### PR TITLE
Feat/claims

### DIFF
--- a/contracts/aid-contract/src/lib.rs
+++ b/contracts/aid-contract/src/lib.rs
@@ -12,3 +12,94 @@ impl AidContract {
         shared::auth::set_admin(&env, &admin);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Bytes, BytesN, Env};
+
+    #[test]
+    fn valid_secret_allows_claim_and_replay_is_blocked() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, AidContract);
+        let client = AidContractClient::new(&env, &contract_id);
+
+        let admin = Address::random(&env);
+        client.initialize(&admin);
+
+        let secret = Bytes::from_array(&env, &[1, 2, 3, 4]);
+        let claim_hash = env.crypto().sha256(&secret);
+        let aid_id = 7u64;
+        let claimant = Address::random(&env);
+
+        client.create_aid(&admin, &aid_id, &Some(claim_hash.clone()), &1u32, &(env.ledger().timestamp() + 100));
+
+        assert!(client.claim_with_secret(&aid_id, &secret, &claimant).is_ok());
+        assert_eq!(client.claim_with_secret(&aid_id, &secret, &claimant), Err(shared::errors::Error::AlreadyClaimed));
+    }
+
+    #[test]
+    fn invalid_secret_is_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, AidContract);
+        let client = AidContractClient::new(&env, &contract_id);
+
+        let admin = Address::random(&env);
+        client.initialize(&admin);
+
+        let secret = Bytes::from_array(&env, &[1, 2, 3, 4]);
+        let wrong_secret = Bytes::from_array(&env, &[9, 9, 9, 9]);
+        let claim_hash = env.crypto().sha256(&secret);
+        let aid_id = 8u64;
+        let claimant = Address::random(&env);
+
+        client.create_aid(&admin, &aid_id, &Some(claim_hash), &1u32, &(env.ledger().timestamp() + 100));
+
+        assert_eq!(client.claim_with_secret(&aid_id, &wrong_secret, &claimant), Err(shared::errors::Error::NotAuthorized));
+    }
+
+    #[test]
+    fn exceeding_max_claims_is_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, AidContract);
+        let client = AidContractClient::new(&env, &contract_id);
+
+        let admin = Address::random(&env);
+        client.initialize(&admin);
+
+        let secret = Bytes::from_array(&env, &[5, 6, 7, 8]);
+        let other_secret = Bytes::from_array(&env, &[9, 10, 11, 12]);
+        let claim_hash = env.crypto().sha256(&secret);
+        let other_claim_hash = env.crypto().sha256(&other_secret);
+        let aid_id = 9u64;
+        let claimant_one = Address::random(&env);
+        let claimant_two = Address::random(&env);
+
+        client.create_aid(&admin, &aid_id, &Some(claim_hash), &1u32, &(env.ledger().timestamp() + 100));
+        assert!(client.claim_with_secret(&aid_id, &secret, &claimant_one).is_ok());
+        assert_eq!(client.claim_with_secret(&aid_id, &other_secret, &claimant_two), Err(shared::errors::Error::AlreadyClaimed));
+    }
+
+    #[test]
+    fn expired_claims_are_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, AidContract);
+        let client = AidContractClient::new(&env, &contract_id);
+
+        let admin = Address::random(&env);
+        client.initialize(&admin);
+
+        let secret = Bytes::from_array(&env, &[13, 14, 15, 16]);
+        let claim_hash = env.crypto().sha256(&secret);
+        let aid_id = 10u64;
+        let claimant = Address::random(&env);
+
+        client.create_aid(&admin, &aid_id, &Some(claim_hash), &1u32, &1u64);
+
+        assert_eq!(client.claim_with_secret(&aid_id, &secret, &claimant), Err(shared::errors::Error::Expired));
+    }
+}

--- a/contracts/aid-contract/src/lib.rs
+++ b/contracts/aid-contract/src/lib.rs
@@ -1,9 +1,25 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, Address, Env};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Bytes, BytesN, Env};
 
 #[contract]
 pub struct AidContract;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct AidClaimMetadata {
+    pub claim_hash: Option<BytesN<32>>,
+    pub max_claims: u32,
+    pub claims_used: u32,
+    pub expires_at: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+enum DataKey {
+    Aid(u64),
+    ClaimNonce(u64, BytesN<32>),
+}
 
 #[contractimpl]
 impl AidContract {
@@ -11,12 +27,79 @@ impl AidContract {
     pub fn initialize(env: Env, admin: Address) {
         shared::auth::set_admin(&env, &admin);
     }
+
+    /// Create a new aid with optional claim-link metadata.
+    pub fn create_aid(
+        env: Env,
+        admin: Address,
+        aid_id: u64,
+        claim_hash: Option<BytesN<32>>,
+        max_claims: u32,
+        expires_at: u64,
+    ) -> Result<(), shared::errors::Error> {
+        shared::auth::require_admin(&env, &admin);
+
+        let metadata = AidClaimMetadata {
+            claim_hash: claim_hash.clone(),
+            max_claims,
+            claims_used: 0,
+            expires_at,
+        };
+
+        env.storage().persistent().set(&DataKey::Aid(aid_id), &metadata);
+        Ok(())
+    }
+
+    /// Claim an aid using a secret whose hash matches the stored claim hash.
+    pub fn claim_with_secret(
+        env: Env,
+        aid_id: u64,
+        secret: Bytes,
+        claimant: Address,
+    ) -> Result<(), shared::errors::Error> {
+        claimant.require_auth();
+
+        let mut metadata = env
+            .storage()
+            .persistent()
+            .get::<DataKey, AidClaimMetadata>(&DataKey::Aid(aid_id))
+            .ok_or(shared::errors::Error::NotFound)?;
+
+        let secret_hash = env.crypto().sha256(&secret);
+
+        match &metadata.claim_hash {
+            Some(expected_hash) if expected_hash != &secret_hash => {
+                return Err(shared::errors::Error::NotAuthorized)
+            }
+            Some(_) => {}
+            None => return Err(shared::errors::Error::NotFound),
+        }
+
+        if env.ledger().timestamp() >= metadata.expires_at {
+            return Err(shared::errors::Error::Expired);
+        }
+
+        let nonce_key = DataKey::ClaimNonce(aid_id, secret_hash.clone());
+        if env.storage().temporary().has(&nonce_key) {
+            return Err(shared::errors::Error::AlreadyClaimed);
+        }
+
+        if metadata.claims_used >= metadata.max_claims {
+            return Err(shared::errors::Error::AlreadyClaimed);
+        }
+
+        metadata.claims_used += 1;
+        env.storage().persistent().set(&DataKey::Aid(aid_id), &metadata);
+        env.storage().temporary().set(&nonce_key, &true);
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::{testutils::Address as _, Bytes, BytesN, Env};
+    use soroban_sdk::testutils::Address as _;
 
     #[test]
     fn valid_secret_allows_claim_and_replay_is_blocked() {
@@ -33,10 +116,15 @@ mod tests {
         let aid_id = 7u64;
         let claimant = Address::random(&env);
 
-        client.create_aid(&admin, &aid_id, &Some(claim_hash.clone()), &1u32, &(env.ledger().timestamp() + 100));
+        client
+            .create_aid(&admin, &aid_id, &Some(claim_hash.clone()), &1u32, &(env.ledger().timestamp() + 100))
+            .unwrap();
 
         assert!(client.claim_with_secret(&aid_id, &secret, &claimant).is_ok());
-        assert_eq!(client.claim_with_secret(&aid_id, &secret, &claimant), Err(shared::errors::Error::AlreadyClaimed));
+        assert_eq!(
+            client.claim_with_secret(&aid_id, &secret, &claimant),
+            Err(shared::errors::Error::AlreadyClaimed)
+        );
     }
 
     #[test]
@@ -55,9 +143,14 @@ mod tests {
         let aid_id = 8u64;
         let claimant = Address::random(&env);
 
-        client.create_aid(&admin, &aid_id, &Some(claim_hash), &1u32, &(env.ledger().timestamp() + 100));
+        client
+            .create_aid(&admin, &aid_id, &Some(claim_hash), &1u32, &(env.ledger().timestamp() + 100))
+            .unwrap();
 
-        assert_eq!(client.claim_with_secret(&aid_id, &wrong_secret, &claimant), Err(shared::errors::Error::NotAuthorized));
+        assert_eq!(
+            client.claim_with_secret(&aid_id, &wrong_secret, &claimant),
+            Err(shared::errors::Error::NotAuthorized)
+        );
     }
 
     #[test]
@@ -73,14 +166,18 @@ mod tests {
         let secret = Bytes::from_array(&env, &[5, 6, 7, 8]);
         let other_secret = Bytes::from_array(&env, &[9, 10, 11, 12]);
         let claim_hash = env.crypto().sha256(&secret);
-        let other_claim_hash = env.crypto().sha256(&other_secret);
         let aid_id = 9u64;
         let claimant_one = Address::random(&env);
         let claimant_two = Address::random(&env);
 
-        client.create_aid(&admin, &aid_id, &Some(claim_hash), &1u32, &(env.ledger().timestamp() + 100));
+        client
+            .create_aid(&admin, &aid_id, &Some(claim_hash), &1u32, &(env.ledger().timestamp() + 100))
+            .unwrap();
         assert!(client.claim_with_secret(&aid_id, &secret, &claimant_one).is_ok());
-        assert_eq!(client.claim_with_secret(&aid_id, &other_secret, &claimant_two), Err(shared::errors::Error::AlreadyClaimed));
+        assert_eq!(
+            client.claim_with_secret(&aid_id, &other_secret, &claimant_two),
+            Err(shared::errors::Error::AlreadyClaimed)
+        );
     }
 
     #[test]
@@ -98,8 +195,13 @@ mod tests {
         let aid_id = 10u64;
         let claimant = Address::random(&env);
 
-        client.create_aid(&admin, &aid_id, &Some(claim_hash), &1u32, &1u64);
+        client
+            .create_aid(&admin, &aid_id, &Some(claim_hash), &1u32, &1u64)
+            .unwrap();
 
-        assert_eq!(client.claim_with_secret(&aid_id, &secret, &claimant), Err(shared::errors::Error::Expired));
+        assert_eq!(
+            client.claim_with_secret(&aid_id, &secret, &claimant),
+            Err(shared::errors::Error::Expired)
+        );
     }
 }

--- a/shared/src/errors.rs
+++ b/shared/src/errors.rs
@@ -7,6 +7,8 @@ use soroban_sdk::contracterror;
 pub enum Error {
     /// Caller is not authorised to perform this action.
     Unauthorized = 1,
+    /// The caller is not authorised for the requested action.
+    NotAuthorized = 9,
     /// The requested item was not found in storage.
     NotFound = 2,
     /// The supplied argument is invalid.


### PR DESCRIPTION
## ✅ Secret-based claim links are now implemented

The aid contract now supports optional secret-backed claim links with the requested behavior:

- Added `create_aid` support for `claim_hash`, `max_claims`, and expiry metadata.
- Added `claim_with_secret(aid_id, secret, claimant)` to:
  - hash the secret and compare it to the stored claim hash,
  - reject wrong secrets with `NotAuthorized`,
  - reject expired claims with `Expired`,
  - enforce the claim limit with `AlreadyClaimed`,
  - block replay of the same secret using temporary nonce storage.

### Updated files
- lib.rs
- errors.rs

### Tests added
The aid contract now includes test coverage for:
- valid secret claims,
- invalid-secret rejection,
- over-limit rejection,
- expired-link rejection,
- replay protection.

### Verification
- Editor diagnostics report no errors for the updated files.
- I was not able to run the Cargo test command in this environment because terminal execution was skipped, so I’m not claiming a test run passed.

Made changes.

closes #11 