### PR TITLE
feat: add typed shared event helpers

### DIFF
--- a/contracts/aid-contract/src/lib.rs
+++ b/contracts/aid-contract/src/lib.rs
@@ -3,7 +3,7 @@
 use soroban_sdk::{
     contract, contractimpl, panic_with_error, token, Address, Env, Symbol, Map,
 };
-use shared::{emit, AID_CREATED, Error};
+use shared::{emit_aid_created, Error};
 
 /// Storage keys
 const KEY_TOKEN: Symbol = Symbol::new("token");
@@ -135,7 +135,15 @@ impl AidContract {
         env.storage().persistent().set(&KEY_AIDS, &aids);
 
         // Emit the AidCreated event
-        emit(&env, AID_CREATED, (aid_id, donor, recipient, amount, current_time, expiry));
+        emit_aid_created(
+            &env,
+            aid_id,
+            &donor,
+            &recipient,
+            amount,
+            current_time,
+            expiry,
+        );
 
         aid_id
     }

--- a/contracts/treasury-contract/src/lib.rs
+++ b/contracts/treasury-contract/src/lib.rs
@@ -4,7 +4,7 @@ use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
 
 use shared::auth::{self, Role};
 use shared::errors::Error;
-use shared::events::{self, TREASURY_WITHDRAW};
+use shared::events::{self, emit_treasury_deposit, emit_treasury_withdrawal};
 
 /// Storage key prefix for per-category balances; the full key is
 /// `(BALANCE, category)`.
@@ -72,10 +72,11 @@ impl TreasuryContract {
         if amount <= 0 {
             return Err(Error::InvalidArgument);
         }
-        let key = (BALANCE, category);
+        let key = (BALANCE, category.clone());
         let balance: i128 = env.storage().instance().get(&key).unwrap_or(0);
         let new_balance = balance.checked_add(amount).ok_or(Error::Overflow)?;
         env.storage().instance().set(&key, &new_balance);
+        emit_treasury_deposit(&env, category, &caller, amount, new_balance);
         Ok(())
     }
 
@@ -101,7 +102,7 @@ impl TreasuryContract {
     ///    -> `Error::InsufficientBalance`
     ///
     /// On success, decrements the category balance and emits the shared
-    /// `TREASURY_WITHDRAW` event with `(category, to, amount, remaining)`.
+    /// `TreasuryWithdrawal` event with `(category, to, amount, remaining)`.
     pub fn withdraw(
         env: Env,
         caller: Address,
@@ -138,7 +139,7 @@ impl TreasuryContract {
         // internal accounting only. If this treasury custodies a live
         // SAC/token, wire a `token::Client::transfer(&to, &amount)` call
         // here (before the event emit) using a stored token address.
-        events::emit(&env, TREASURY_WITHDRAW, (category, to, amount, remaining));
+        emit_treasury_withdrawal(&env, category, &to, amount, remaining);
 
         Ok(())
     }

--- a/shared/README.md
+++ b/shared/README.md
@@ -71,3 +71,34 @@ than once.
 4. Use the `900-999` range only for errors shared by multiple contracts.
 5. Update this document whenever a new error code is introduced.
 6. Update the uniqueness and stability tests when adding a shared variant.
+
+## Event schemas
+
+Protocol events use stable two-part topic tuples. Off-chain indexers should
+match both topic symbols and decode the data using the documented order and
+types.
+
+The legacy single-symbol constants and generic `emit` helper remain available
+for backward compatibility. New protocol code should use the typed helpers in
+`shared::events`.
+
+| Event | Helper | Topics | Data |
+|---|---|---|---|
+| `AidCreated` | `emit_aid_created` | `("aid", "created")` | `(u64 aid_id, Address donor, Address recipient, i128 amount, u64 created_at, u64 expires_at)` |
+| `AidClaimed` | `emit_aid_claimed` | `("aid", "claimed")` | `(u64 aid_id, Address claimant, u64 claimed_at)` |
+| `AidSettled` | `emit_aid_settled` | `("aid", "settled")` | `(u64 aid_id, Address recipient, i128 amount, u64 settled_at)` |
+| `AidRefunded` | `emit_aid_refunded` | `("aid", "refunded")` | `(u64 aid_id, Address donor, i128 amount, u64 refunded_at)` |
+| `CommissionPaid` | `emit_commission_paid` | `("comm", "paid")` | `(Address recipient, i128 amount, u64 paid_at)` |
+| `TreasuryDeposit` | `emit_treasury_deposit` | `("treasury", "deposit")` | `(Symbol category, Address depositor, i128 amount, i128 new_balance)` |
+| `TreasuryWithdrawal` | `emit_treasury_withdrawal` | `("treasury", "withdraw")` | `(Symbol category, Address recipient, i128 amount, i128 remaining_balance)` |
+| `ContractPaused` | `emit_contract_paused` | `("contract", "paused")` | `(Address actor, u64 paused_at)` |
+| `ContractResumed` | `emit_contract_resumed` | `("contract", "resumed")` | `(Address actor, u64 resumed_at)` |
+| `ContractUpgraded` | `emit_contract_upgraded` | `("contract", "upgraded")` | `(Address actor, BytesN<32> wasm_hash, u64 upgraded_at)` |
+
+### Event stability rules
+
+1. Do not change a published event's topic tuple.
+2. Do not reorder, remove, or change the type of existing data fields.
+3. Add new event versions instead of silently changing an existing schema.
+4. Use the typed helper whenever one exists.
+5. Update this table and the event tests whenever a new schema is introduced.

--- a/shared/src/events.rs
+++ b/shared/src/events.rs
@@ -1,6 +1,6 @@
-use soroban_sdk::{symbol_short, Env, Symbol};
+use soroban_sdk::{symbol_short, Address, BytesN, Env, Symbol};
 
-/// Event topic constants shared across contracts.
+/// Legacy single-topic constants retained for backward compatibility.
 pub const AID_CREATED: Symbol = symbol_short!("aid_crt");
 pub const AID_CLAIMED: Symbol = symbol_short!("aid_clm");
 pub const AID_SETTLED: Symbol = symbol_short!("aid_stl");
@@ -17,7 +17,227 @@ pub const CONTRACT_PAUSED: Symbol = symbol_short!("paused");
 pub const CONTRACT_RESUMED: Symbol = symbol_short!("resumed");
 pub const CONTRACT_UPGRADED: Symbol = symbol_short!("upgraded");
 
-/// Emit an event with a single data value.
+/// Emits `AidCreated`.
+///
+/// Topics: `("aid", "created")`
+///
+/// Data:
+/// `(aid_id, donor, recipient, amount, created_at, expires_at)`
+pub fn emit_aid_created(
+    env: &Env,
+    aid_id: u64,
+    donor: &Address,
+    recipient: &Address,
+    amount: i128,
+    created_at: u64,
+    expires_at: u64,
+) {
+    env.events().publish(
+        (symbol_short!("aid"), symbol_short!("created")),
+        (
+            aid_id,
+            donor.clone(),
+            recipient.clone(),
+            amount,
+            created_at,
+            expires_at,
+        ),
+    );
+}
+
+/// Emits `AidClaimed`.
+///
+/// Topics: `("aid", "claimed")`
+///
+/// Data: `(aid_id, claimant, claimed_at)`
+pub fn emit_aid_claimed(env: &Env, aid_id: u64, claimant: &Address, claimed_at: u64) {
+    env.events().publish(
+        (symbol_short!("aid"), symbol_short!("claimed")),
+        (aid_id, claimant.clone(), claimed_at),
+    );
+}
+
+/// Emits `AidSettled`.
+///
+/// Topics: `("aid", "settled")`
+///
+/// Data: `(aid_id, recipient, amount, settled_at)`
+pub fn emit_aid_settled(
+    env: &Env,
+    aid_id: u64,
+    recipient: &Address,
+    amount: i128,
+    settled_at: u64,
+) {
+    env.events().publish(
+        (symbol_short!("aid"), symbol_short!("settled")),
+        (aid_id, recipient.clone(), amount, settled_at),
+    );
+}
+
+/// Emits `AidRefunded`.
+///
+/// Topics: `("aid", "refunded")`
+///
+/// Data: `(aid_id, donor, amount, refunded_at)`
+pub fn emit_aid_refunded(env: &Env, aid_id: u64, donor: &Address, amount: i128, refunded_at: u64) {
+    env.events().publish(
+        (symbol_short!("aid"), symbol_short!("refunded")),
+        (aid_id, donor.clone(), amount, refunded_at),
+    );
+}
+
+/// Emits `CommissionPaid`.
+///
+/// Topics: `("comm", "paid")`
+///
+/// Data: `(recipient, amount, paid_at)`
+pub fn emit_commission_paid(env: &Env, recipient: &Address, amount: i128, paid_at: u64) {
+    env.events().publish(
+        (symbol_short!("comm"), symbol_short!("paid")),
+        (recipient.clone(), amount, paid_at),
+    );
+}
+
+/// Emits `TreasuryDeposit`.
+///
+/// Topics: `("treasury", "deposit")`
+///
+/// Data: `(category, depositor, amount, new_balance)`
+pub fn emit_treasury_deposit(
+    env: &Env,
+    category: Symbol,
+    depositor: &Address,
+    amount: i128,
+    new_balance: i128,
+) {
+    env.events().publish(
+        (symbol_short!("treasury"), symbol_short!("deposit")),
+        (category, depositor.clone(), amount, new_balance),
+    );
+}
+
+/// Emits `TreasuryWithdrawal`.
+///
+/// Topics: `("treasury", "withdraw")`
+///
+/// Data: `(category, recipient, amount, remaining_balance)`
+pub fn emit_treasury_withdrawal(
+    env: &Env,
+    category: Symbol,
+    recipient: &Address,
+    amount: i128,
+    remaining_balance: i128,
+) {
+    env.events().publish(
+        (symbol_short!("treasury"), symbol_short!("withdraw")),
+        (category, recipient.clone(), amount, remaining_balance),
+    );
+}
+
+/// Emits `ContractPaused`.
+///
+/// Topics: `("contract", "paused")`
+///
+/// Data: `(actor, paused_at)`
+pub fn emit_contract_paused(env: &Env, actor: &Address, paused_at: u64) {
+    env.events().publish(
+        (symbol_short!("contract"), symbol_short!("paused")),
+        (actor.clone(), paused_at),
+    );
+}
+
+/// Emits `ContractResumed`.
+///
+/// Topics: `("contract", "resumed")`
+///
+/// Data: `(actor, resumed_at)`
+pub fn emit_contract_resumed(env: &Env, actor: &Address, resumed_at: u64) {
+    env.events().publish(
+        (symbol_short!("contract"), symbol_short!("resumed")),
+        (actor.clone(), resumed_at),
+    );
+}
+
+/// Emits `ContractUpgraded`.
+///
+/// Topics: `("contract", "upgraded")`
+///
+/// Data: `(actor, wasm_hash, upgraded_at)`
+pub fn emit_contract_upgraded(
+    env: &Env,
+    actor: &Address,
+    wasm_hash: &BytesN<32>,
+    upgraded_at: u64,
+) {
+    env.events().publish(
+        (symbol_short!("contract"), symbol_short!("upgraded")),
+        (actor.clone(), wasm_hash.clone(), upgraded_at),
+    );
+}
+
+/// Emits an event using a legacy single-symbol topic.
+///
+/// New protocol events should use one of the typed helpers above.
 pub fn emit<T: soroban_sdk::IntoVal<Env, soroban_sdk::Val>>(env: &Env, topic: Symbol, data: T) {
     env.events().publish((topic,), data);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::emit_aid_created;
+    use soroban_sdk::{
+        contract, contractimpl, symbol_short,
+        testutils::{Address as _, Events},
+        Address, Env, FromVal, IntoVal,
+    };
+
+    #[contract]
+    struct EventTestContract;
+
+    #[contractimpl]
+    impl EventTestContract {
+        pub fn publish_aid_created(
+            env: Env,
+            aid_id: u64,
+            donor: Address,
+            recipient: Address,
+            amount: i128,
+            created_at: u64,
+            expires_at: u64,
+        ) {
+            emit_aid_created(
+                &env, aid_id, &donor, &recipient, amount, created_at, expires_at,
+            );
+        }
+    }
+
+    #[test]
+    fn aid_created_has_stable_topics_and_data() {
+        let env = Env::default();
+        let donor = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let contract_id = env.register(EventTestContract, ());
+        let client = EventTestContractClient::new(&env, &contract_id);
+
+        client.publish_aid_created(&7, &donor, &recipient, &500, &100, &1_000);
+
+        let events = env.events().all();
+        assert_eq!(events.len(), 1);
+
+        let (emitter, topics, data) = events.get(0).unwrap();
+
+        assert_eq!(emitter, contract_id);
+        assert_eq!(
+            topics,
+            (symbol_short!("aid"), symbol_short!("created"),).into_val(&env)
+        );
+        let decoded_data: (u64, Address, Address, i128, u64, u64) =
+            FromVal::from_val(&env, &data);
+
+        assert_eq!(
+            decoded_data,
+            (7u64, donor, recipient, 500i128, 100u64, 1_000u64)
+        );
+    }
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,5 +1,12 @@
 #![no_std]
 
+pub mod auth;
+pub mod errors;
+pub mod events;
+pub mod math;
+pub mod storage;
+pub mod utils;
+
 pub use auth::*;
 pub use errors::*;
 pub use events::*;


### PR DESCRIPTION
Closes #3

## Description

Adds typed, centralized event helpers for the 10 protocol events listed in the
README so off-chain indexers can rely on stable topic tuples and documented data
payloads.

The implementation keeps the existing single-symbol constants and generic
`emit` helper for backward compatibility, while introducing explicit helpers
for new protocol code.

## Linked Issue

Closes #3

## Type of Change

- [x] ✨ New feature
- [x] 📝 Documentation update
- [x] 🧪 Tests
- [x] 🔧 Compatibility / baseline repair
- [ ] 🐛 Bug fix

## Changes Made

### `shared/src/events.rs`

Adds typed helpers for all 10 required events:

- `emit_aid_created`
- `emit_aid_claimed`
- `emit_aid_settled`
- `emit_aid_refunded`
- `emit_commission_paid`
- `emit_treasury_deposit`
- `emit_treasury_withdrawal`
- `emit_contract_paused`
- `emit_contract_resumed`
- `emit_contract_upgraded`

Each helper publishes a stable two-part topic tuple and a fixed, typed payload.

The existing legacy constants and generic `emit` helper remain available so
previously merged contracts are not broken.

### `contracts/aid-contract/src/lib.rs`

Replaces the generic Aid creation event with:

```rust
emit_aid_created(...)
```

The emitted schema is:

- Topics: `("aid", "created")`
- Data:
  `(aid_id, donor, recipient, amount, created_at, expires_at)`

### `contracts/treasury-contract/src/lib.rs`

Adds a typed event to successful deposits:

```rust
emit_treasury_deposit(...)
```

Replaces the generic withdrawal event with:

```rust
emit_treasury_withdrawal(...)
```

The schemas are:

- `TreasuryDeposit`
  - Topics: `("treasury", "deposit")`
  - Data: `(category, depositor, amount, new_balance)`

- `TreasuryWithdrawal`
  - Topics: `("treasury", "withdraw")`
  - Data: `(category, recipient, amount, remaining_balance)`

The existing emergency-withdraw event was not changed because it is outside the
10-event catalog required by this issue.

### `shared/README.md`

Documents:

- All 10 event names.
- The typed helper associated with each event.
- The exact topic tuple.
- The order and type of every data field.
- Stability rules for future event changes.

### `shared/src/lib.rs`

Restores the missing module declarations:

```rust
pub mod auth;
pub mod errors;
pub mod events;
pub mod math;
pub mod storage;
pub mod utils;
```

This was required because the latest `main` re-exported these modules without
declaring them, causing unresolved-import errors before the event helpers could
be compiled or tested.

## Event Schema Catalog

| Event | Topics | Data |
|---|---|---|
| `AidCreated` | `("aid", "created")` | `(u64 aid_id, Address donor, Address recipient, i128 amount, u64 created_at, u64 expires_at)` |
| `AidClaimed` | `("aid", "claimed")` | `(u64 aid_id, Address claimant, u64 claimed_at)` |
| `AidSettled` | `("aid", "settled")` | `(u64 aid_id, Address recipient, i128 amount, u64 settled_at)` |
| `AidRefunded` | `("aid", "refunded")` | `(u64 aid_id, Address donor, i128 amount, u64 refunded_at)` |
| `CommissionPaid` | `("comm", "paid")` | `(Address recipient, i128 amount, u64 paid_at)` |
| `TreasuryDeposit` | `("treasury", "deposit")` | `(Symbol category, Address depositor, i128 amount, i128 new_balance)` |
| `TreasuryWithdrawal` | `("treasury", "withdraw")` | `(Symbol category, Address recipient, i128 amount, i128 remaining_balance)` |
| `ContractPaused` | `("contract", "paused")` | `(Address actor, u64 paused_at)` |
| `ContractResumed` | `("contract", "resumed")` | `(Address actor, u64 resumed_at)` |
| `ContractUpgraded` | `("contract", "upgraded")` | `(Address actor, BytesN<32> wasm_hash, u64 upgraded_at)` |

## Test Evidence

- [x] `git diff --check`
- [x] The `AidCreated` event test passed in an isolated Soroban test environment.
- [x] The test verified the emitting contract address.
- [x] The test verified the exact two-part topic tuple.
- [x] The test decoded and verified the exact typed payload.
- [x] Aid uses a typed shared helper.
- [x] Treasury uses typed shared helpers for both deposit and withdrawal.

Successful isolated test result:

```text
test events::tests::aid_created_has_stable_topics_and_data ... ok

test result: ok. 1 passed; 0 failed
EVENT TEST EXIT CODE: 0
```

## Important Baseline Problems Found

The latest `main` already contained multiple regressions before this branch was
modified.

### 1. Missing module declarations in `shared/src/lib.rs`

`main` contained re-exports such as:

```rust
pub use auth::*;
pub use errors::*;
pub use events::*;
```

but no corresponding `pub mod auth;`, `pub mod errors;`, or `pub mod events;`
declarations.

This caused `shared` to fail immediately with unresolved-import errors. This PR
includes the minimum restoration required to expose the shared modules and
implement this issue.

### 2. Duplicate authorization definitions in `shared/src/auth.rs`

After restoring the module declarations, compilation exposed pre-existing
duplicate definitions in `shared/src/auth.rs`, including:

- `Role`
- `grant_role`
- `revoke_role`
- `has_role`
- `require_role`

These duplicates currently prevent a normal full `shared` or workspace build.
They were not introduced or modified by this PR.

### 3. Shared error-code regression

The merged shared error-code implementation is still present in Git history,
but later commits replaced parts of `shared/src/errors.rs`.

As a result:

- `shared/README.md` documents the stable `900-909` shared codes.
- The current source contains older `1-9` codes and different variants.
- The uniqueness and stability tests from the merged error-code PR are no
  longer present in the current file.

This inconsistency was not changed in this PR because it is outside the scope of
the event-helper issue.

### 4. Soroban test dependency resolution

With the repository's default dependency resolution, Soroban test utilities
resolved an incompatible combination involving:

- `soroban-env-host 22.1.3`
- `ed25519-dalek 3.0.0`
- `rand_chacha 0.3.1`

This failed inside the dependency before the event test could run.

For isolated validation only, a temporary `Cargo.lock` pinned
`ed25519-dalek` to `2.2.0`. The event test then compiled and passed.

The temporary lockfile and dependency adjustment were removed after validation
and are not included in this PR.

## Validation Limitations

A clean full-workspace validation is currently blocked by the pre-existing
duplicate definitions in `shared/src/auth.rs`.

This PR therefore does not claim that the current repository baseline is fully
green. It does demonstrate that the event helper implementation itself compiles
and that the required event topic and data schema test passes when isolated from
the unrelated baseline regressions.

## Acceptance Criteria

- [x] All 10 README events have typed helpers.
- [x] All 10 events have documented topics and data schemas.
- [x] Aid uses a shared typed event helper.
- [x] Treasury uses shared typed event helpers.
- [x] A Soroban test asserts an emitted event's topics and data.
- [x] Event schemas are documented in `shared/README.md`.
- [x] Legacy event APIs remain available for backward compatibility.
- [x] Known baseline problems are explicitly documented.

## Files Changed

- `shared/src/events.rs`
- `shared/src/lib.rs`
- `shared/README.md`
- `contracts/aid-contract/src/lib.rs`
- `contracts/treasury-contract/src/lib.rs`
