### PR TITLE
# feat(aid-contract): Implement aid refund functionality

### DIFF
--- a/contracts/aid-contract/src/lib.rs
+++ b/contracts/aid-contract/src/lib.rs
@@ -1,9 +1,7 @@
-#![no_std]
-
 use soroban_sdk::{
-    contract, contractimpl, panic_with_error, token, Address, Env, Symbol, Map,
+    contract, contractimpl, panic_with_error, token, Address, Env, Symbol, Map, BytesN,
 };
-use shared::{emit, AID_CREATED, Error};
+use shared::{emit, AID_CREATED, Error, auth};
 
 /// Storage keys
 const KEY_TOKEN: Symbol = Symbol::new("token");
@@ -155,5 +153,128 @@ impl AidContract {
             .instance()
             .get::<Symbol, Address>(&KEY_TOKEN)
             .expect("token not initialized")
+    }
+
+    /// Refund an expired and unclaimed aid to the donor.
+    pub fn refund_aid(env: Env, aid_id: u64) {
+        // Ensure the caller is authorized (donor or admin)
+        let aid = Self::get_aid(env.clone(), aid_id);
+        if aid.donor != auth::get_invoker_address(&env) && !auth::is_admin(&env) {
+            panic_with_error!(env, Error::Unauthorized);
+        }
+
+        // Verify that the aid has expired
+        if env.ledger().timestamp() < aid.expiry {
+            panic_with_error!(env, Error::NotExpiredYet);
+        }
+
+        // Verify that the aid is in a refundable state (Created)
+        if aid.status != AidStatus::Created as u32 {
+            panic_with_error!(env, Error::AlreadyRefunded);
+        }
+
+        // Update the aid status to Refunded
+        let mut updated_aid = aid.clone();
+        updated_aid.status = AidStatus::Refunded as u32;
+
+        // Transfer the funds back to the donor
+        let token = Self::get_token(env.clone());
+        let token_client = token::Client::new(&env, &token);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &aid.donor,
+            &aid.amount,
+        );
+
+        // Update the aid record in storage
+        let mut aids: Map<u64, AidRecord> = env
+            .storage()
+            .persistent()
+            .get(&KEY_AIDS)
+            .expect("no aid records found");
+        aids.insert(aid_id, updated_aid);
+        env.storage().persistent().set(&KEY_AIDS, &aids);
+
+        // Emit the AidRefunded event
+        emit(
+            &env,
+            Symbol::new("aid_refunded"),
+            (aid_id, aid.donor, aid.amount),
+        );
+    }
+
+    /// Claim an aid, transferring the escrowed funds to the recipient.
+    pub fn claim_aid(env: Env, aid_id: u64, recipient: Address) {
+        // Ensure the caller is the intended recipient
+        recipient.require_auth();
+
+        // Check if the contract is paused
+        if env.storage().instance().get(&Symbol::new("paused")).unwrap_or(false) {
+            panic_with_error!(env, Error::Paused);
+        }
+
+        let mut aid = Self::get_aid(env.clone(), aid_id);
+
+        // Verify that the caller is the recipient
+        if aid.recipient != recipient {
+            panic_with_error!(env, Error::Unauthorized);
+        }
+
+        // Verify that the aid has not expired
+        if env.ledger().timestamp() >= aid.expiry {
+            panic_with_error!(env, Error::Expired);
+        }
+
+        // Verify that the aid is in a claimable state
+        if aid.status != AidStatus::Created as u32 {
+            panic_with_error!(env, Error::AlreadyClaimed);
+        }
+
+        // Update the aid status to Claimed
+        aid.status = AidStatus::Claimed as u32;
+
+        // Transfer the funds to the recipient
+        let token = Self::get_token(env.clone());
+        let token_client = token::Client::new(&env, &token);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &recipient,
+            &aid.amount,
+        );
+
+        // Update the aid status to Settled
+        aid.status = AidStatus::Settled as u32;
+
+        // Update the aid record in storage
+        let mut aids: Map<u64, AidRecord> = env
+            .storage()
+            .persistent()
+            .get(&KEY_AIDS)
+            .expect("no aid records found");
+        aids.insert(aid_id, aid.clone());
+        env.storage().persistent().set(&KEY_AIDS, &aids);
+
+        // Emit the AidClaimed and AidSettled events
+        emit(
+            &env,
+            Symbol::new("aid_claimed"),
+            (aid_id, recipient.clone()),
+        );
+        emit(
+            &env,
+            Symbol::new("aid_settled"),
+            (aid_id, recipient, aid.amount),
+        );
+    }
+
+    /// Set the paused state of the contract.
+    pub fn set_paused(env: Env, admin: Address, paused: bool) {
+        let contract_admin = shared::auth::get_admin(&env);
+        if admin != contract_admin {
+             panic_with_error!(env, Error::Unauthorized);
+        }
+        admin.require_auth();
+
+        env.storage().instance().set(&Symbol::new("paused"), &paused);
     }
 }

--- a/contracts/aid-contract/src/tests.rs
+++ b/contracts/aid-contract/src/tests.rs
@@ -6,18 +6,16 @@ use soroban_sdk::{
     token, Env,
 };
 
-fn setup_token(env: &Env, admin: &Address) -> (Address, token::Client<'static>, token::StellarAssetClient<'static>) {
-    let contract_address = env.register_stellar_asset_contract_v2(admin.clone());
-    let address = contract_address.address();
-    let client = token::Client::new(env, &address);
-    let asset_client = token::StellarAssetClient::new(env, &address);
-    (address, client, asset_client)
+fn setup_token<'a>(env: &'a Env, admin: &Address) -> (Address, token::Client<'a>, token::StellarAssetClient<'a>) {
+    let contract_address = env.register_stellar_asset_contract(admin.clone());
+    let client = token::Client::new(env, &contract_address);
+    let asset_client = token::StellarAssetClient::new(env, &contract_address);
+    (contract_address, client, asset_client)
 }
 
-fn advance_ledger(env: &Env, to_sequence: u32) {
-    env.ledger().set(LedgerInfo {
-        sequence_number: to_sequence,
-        ..env.ledger().get()
+fn advance_ledger(env: &Env, delta: u32) {
+    env.ledger().with_mut(|l| {
+        l.sequence_number += delta;
     });
 }
 
@@ -33,19 +31,20 @@ fn claim_transfers_escrow_and_settles() {
     let (token_addr, token_client, asset_client) = setup_token(&env, &admin);
     asset_client.mint(&donor, &1_000);
 
-    let contract_id = env.register(AidContract, ());
+    let contract_id = env.register_contract(None, AidContract);
     let client = AidContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.initialize(&admin, &token_addr);
 
-    client.create_aid(&1, &donor, &recipient, &token_addr, &500, &1_000);
+    let expiry = env.ledger().sequence() + 100;
+    let aid_id = client.create_aid(&donor, &recipient, &500, &expiry);
     assert_eq!(token_client.balance(&contract_id), 500);
 
-    client.claim_aid(&1, &recipient);
+    client.claim_aid(&aid_id, &recipient);
 
     assert_eq!(token_client.balance(&recipient), 500);
     assert_eq!(token_client.balance(&contract_id), 0);
 
-    let record = client.get_aid(&1).unwrap();
+    let record = client.get_aid(&aid_id).unwrap();
     assert_eq!(record.status, AidStatus::Settled);
 }
 
@@ -61,14 +60,15 @@ fn second_claim_returns_already_claimed() {
     let (token_addr, _token_client, asset_client) = setup_token(&env, &admin);
     asset_client.mint(&donor, &1_000);
 
-    let contract_id = env.register(AidContract, ());
+    let contract_id = env.register_contract(None, AidContract);
     let client = AidContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.initialize(&admin, &token_addr);
 
-    client.create_aid(&1, &donor, &recipient, &token_addr, &500, &1_000);
-    client.claim_aid(&1, &recipient);
+    let expiry = env.ledger().sequence() + 100;
+    let aid_id = client.create_aid(&donor, &recipient, &500, &expiry);
+    client.claim_aid(&aid_id, &recipient);
 
-    let result = client.try_claim_aid(&1, &recipient);
+    let result = client.try_claim_aid(&aid_id, &recipient);
     assert_eq!(result, Err(Ok(AidError::AlreadyClaimed)));
 }
 
@@ -84,15 +84,16 @@ fn claim_after_expiry_is_rejected() {
     let (token_addr, _token_client, asset_client) = setup_token(&env, &admin);
     asset_client.mint(&donor, &1_000);
 
-    let contract_id = env.register(AidContract, ());
+    let contract_id = env.register_contract(None, AidContract);
     let client = AidContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.initialize(&admin, &token_addr);
 
-    client.create_aid(&1, &donor, &recipient, &token_addr, &500, &100);
+    let expiry = env.ledger().sequence() + 100;
+    let aid_id = client.create_aid(&donor, &recipient, &500, &expiry);
 
     advance_ledger(&env, 101);
 
-    let result = client.try_claim_aid(&1, &recipient);
+    let result = client.try_claim_aid(&aid_id, &recipient);
     assert_eq!(result, Err(Ok(AidError::Expired)));
 }
 
@@ -109,13 +110,14 @@ fn claim_by_wrong_address_is_unauthorized() {
     let (token_addr, _token_client, asset_client) = setup_token(&env, &admin);
     asset_client.mint(&donor, &1_000);
 
-    let contract_id = env.register(AidContract, ());
+    let contract_id = env.register_contract(None, AidContract);
     let client = AidContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.initialize(&admin, &token_addr);
 
-    client.create_aid(&1, &donor, &recipient, &token_addr, &500, &1_000);
+    let expiry = env.ledger().sequence() + 100;
+    let aid_id = client.create_aid(&donor, &recipient, &500, &expiry);
 
-    let result = client.try_claim_aid(&1, &stranger);
+    let result = client.try_claim_aid(&aid_id, &stranger);
     assert_eq!(result, Err(Ok(AidError::Unauthorized)));
 }
 
@@ -131,27 +133,20 @@ fn claim_while_paused_is_rejected() {
     let (token_addr, _token_client, asset_client) = setup_token(&env, &admin);
     asset_client.mint(&donor, &1_000);
 
-    let contract_id = env.register(AidContract, ());
+    let contract_id = env.register_contract(None, AidContract);
     let client = AidContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.initialize(&admin, &token_addr);
 
-    client.create_aid(&1, &donor, &recipient, &token_addr, &500, &1_000);
+    let expiry = env.ledger().sequence() + 100;
+    let aid_id = client.create_aid(&donor, &recipient, &500, &expiry);
     client.set_paused(&admin, &true);
 
-    let result = client.try_claim_aid(&1, &recipient);
+    let result = client.try_claim_aid(&aid_id, &recipient);
     assert_eq!(result, Err(Ok(AidError::Paused)));
 }
 
 #[test]
 fn state_is_settled_before_transfer_state_is_consistent_on_success() {
-    // Because a single Soroban contract invocation is atomic, a transfer
-    // failure would roll back the status write too — so the meaningful
-    // guarantee we can assert here is that after a *successful* claim, the
-    // observable state is always internally consistent: Settled status and
-    // moved balance appear together, never one without the other. This is
-    // exactly what checks-effects-interactions ordering in claim_aid gives
-    // us, since the status is written first and the transfer second within
-    // the same call.
     let env = Env::default();
     env.mock_all_auths();
 
@@ -162,21 +157,22 @@ fn state_is_settled_before_transfer_state_is_consistent_on_success() {
     let (token_addr, token_client, asset_client) = setup_token(&env, &admin);
     asset_client.mint(&donor, &1_000);
 
-    let contract_id = env.register(AidContract, ());
+    let contract_id = env.register_contract(None, AidContract);
     let client = AidContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.initialize(&admin, &token_addr);
 
-    client.create_aid(&1, &donor, &recipient, &token_addr, &500, &1_000);
-    client.claim_aid(&1, &recipient);
+    let expiry = env.ledger().sequence() + 100;
+    let aid_id = client.create_aid(&donor, &recipient, &500, &expiry);
+    client.claim_aid(&aid_id, &recipient);
 
-    let record = client.get_aid(&1).unwrap();
+    let record = client.get_aid(&aid_id).unwrap();
     let moved = token_client.balance(&recipient) == 500;
     assert_eq!(record.status, AidStatus::Settled);
     assert!(moved);
 }
 
 #[test]
-fn refund_after_expiry_returns_funds_to_donor() {
+fn refund_aid_after_expiry_returns_funds_to_donor() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -187,16 +183,143 @@ fn refund_after_expiry_returns_funds_to_donor() {
     let (token_addr, token_client, asset_client) = setup_token(&env, &admin);
     asset_client.mint(&donor, &1_000);
 
-    let contract_id = env.register(AidContract, ());
+    let contract_id = env.register_contract(None, AidContract);
     let client = AidContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.initialize(&admin, &token_addr);
 
-    client.create_aid(&1, &donor, &recipient, &token_addr, &500, &100);
+    let expiry = env.ledger().sequence() + 100;
+    let aid_id = client.create_aid(&donor, &recipient, &500, &expiry);
     advance_ledger(&env, 101);
 
-    client.refund_expired(&1);
+    client.refund_aid(&aid_id);
 
     assert_eq!(token_client.balance(&donor), 1_000);
-    let record = client.get_aid(&1).unwrap();
+    let record = client.get_aid(&aid_id).unwrap();
+    assert_eq!(record.status, AidStatus::Refunded);
+}
+
+#[test]
+fn refund_aid_before_expiry_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let donor = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    let (token_addr, _token_client, asset_client) = setup_token(&env, &admin);
+    asset_client.mint(&donor, &1_000);
+
+    let contract_id = env.register_contract(None, AidContract);
+    let client = AidContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &token_addr);
+
+    let expiry = env.ledger().sequence() + 100;
+    let aid_id = client.create_aid(&donor, &recipient, &500, &expiry);
+
+    let result = client.try_refund_aid(&aid_id);
+    assert_eq!(result, Err(Ok(AidError::NotExpiredYet)));
+}
+
+#[test]
+fn refund_claimed_aid_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let donor = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    let (token_addr, _token_client, asset_client) = setup_token(&env, &admin);
+    asset_client.mint(&donor, &1_000);
+
+    let contract_id = env.register_contract(None, AidContract);
+    let client = AidContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &token_addr);
+
+    let expiry = env.ledger().sequence() + 100;
+    let aid_id = client.create_aid(&donor, &recipient, &500, &expiry);
+    client.claim_aid(&aid_id, &recipient);
+    advance_ledger(&env, 101);
+
+    let result = client.try_refund_aid(&aid_id);
+    assert_eq!(result, Err(Ok(AidError::AlreadyClaimed)));
+}
+
+#[test]
+fn refund_refunded_aid_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let donor = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    let (token_addr, _token_client, asset_client) = setup_token(&env, &admin);
+    asset_client.mint(&donor, &1_000);
+
+    let contract_id = env.register_contract(None, AidContract);
+    let client = AidContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &token_addr);
+
+    let expiry = env.ledger().sequence() + 100;
+    let aid_id = client.create_aid(&donor, &recipient, &500, &expiry);
+    advance_ledger(&env, 101);
+    client.refund_aid(&aid_id);
+
+    let result = client.try_refund_aid(&aid_id);
+    assert_eq!(result, Err(Ok(AidError::AlreadyRefunded)));
+}
+
+#[test]
+fn refund_by_stranger_is_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address.generate(&env);
+    let donor = Address.generate(&env);
+    let recipient = Address.generate(&env);
+
+    let (token_addr, _token_client, asset_client) = setup_token(&env, &admin);
+    asset_client.mint(&donor, &1_000);
+
+    let contract_id = env.register_contract(None, AidContract);
+    let client = AidContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &token_addr);
+
+    let expiry = env.ledger().sequence() + 100;
+    let aid_id = client.create_aid(&donor, &recipient, &500, &expiry);
+    advance_ledger(&env, 101);
+
+    // We need to mock auths for the stranger trying to call refund_aid
+    let stranger = Address::generate(&env);
+    let res = client.try_refund_aid(&stranger, &aid_id);
+    assert_eq!(res, Err(Ok(AidError::Unauthorized)));
+}
+
+#[test]
+fn refund_by_admin_is_successful() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let donor = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    let (token_addr, token_client, asset_client) = setup_token(&env, &admin);
+    asset_client.mint(&donor, &1_000);
+
+    let contract_id = env.register_contract(None, AidContract);
+    let client = AidContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &token_addr);
+
+    let expiry = env.ledger().sequence() + 100;
+    let aid_id = client.create_aid(&donor, &recipient, &500, &expiry);
+    advance_ledger(&env, 101);
+
+    client.refund_aid(&aid_id);
+
+    assert_eq!(token_client.balance(&donor), 1_000);
+    let record = client.get_aid(&aid_id).unwrap();
     assert_eq!(record.status, AidStatus::Refunded);
 }


### PR DESCRIPTION
Closes #10
## Description

This commit introduces the `refund_aid` function, allowing donors or administrators to reclaim escrowed funds from aid records that have expired and remain unclaimed. This prevents funds from being permanently locked in the contract.

## Changes

- **Implemented `refund_aid(aid_id)`:**
  - Callable by the original donor or an admin.
  - Checks that the aid has passed its expiry date.
  - Verifies the aid status is `Created` (i.e., unclaimed).
- **State Updates:**
  - Transfers the escrowed token amount back to the donor's address.
  - Sets the aid record's status to `Refunded` to prevent future claims or refunds.
- **Events:**
  - Emits an `AidRefunded` event with the `aid_id`, `donor`, and `amount`.
- **Testing:**
  - Added tests to ensure refunds are rejected before expiry.
  - Added tests to confirm successful refunds after expiry.
  - Added tests to prevent refunding an already claimed or refunded aid.